### PR TITLE
Added Game Manager, Unlock Zone script, Structure Builder Script

### DIFF
--- a/Assets/Scenes/TestScene_Jacob.unity
+++ b/Assets/Scenes/TestScene_Jacob.unity
@@ -275,7 +275,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: -6629797300637803691, guid: e043227803a5a6b4eae230acae5a3223, type: 3}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -414,6 +414,126 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &441231754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 441231759}
+  - component: {fileID: 441231758}
+  - component: {fileID: 441231757}
+  - component: {fileID: 441231756}
+  - component: {fileID: 441231755}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &441231755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441231754}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3c58a641b60f8e24cbe7ef9f4568decf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  price: 100
+  structureToUnlock: {fileID: 1651730331}
+--- !u!65 &441231756
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441231754}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &441231757
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441231754}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10301, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &441231758
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441231754}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &441231759
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 441231754}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.6600008, y: -0.88, z: -0.13999939}
+  m_LocalScale: {x: 2.4672, y: 0.24696673, z: 2.4672}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1651730334}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &999191521
 GameObject:
   m_ObjectHideFlags: 0
@@ -1301,6 +1421,30 @@ LineRenderer:
   m_UseWorldSpace: 0
   m_Loop: 0
   m_ApplyActiveColorSpace: 1
+--- !u!1 &1651730331 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2943495585636308200, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
+  m_PrefabInstance: {fileID: 1991865841}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1651730332
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1651730331}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdf332ba2695e004e9c865a7ba33350c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  structure: {fileID: 1651730334}
+  buildTime: 2
+--- !u!4 &1651730334 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2279407066166407645, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
+  m_PrefabInstance: {fileID: 1991865841}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1668805358
 GameObject:
   m_ObjectHideFlags: 0
@@ -1469,6 +1613,51 @@ MonoBehaviour:
   holdPoint: {fileID: 1582829154}
   stackHeight: 0.5
   pickupSpeed: 0.5
+--- !u!1 &1684896413
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1684896415}
+  - component: {fileID: 1684896414}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1684896414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684896413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd345a658a2cc7439a64e8d9b496995, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playerMoney: 200
+--- !u!4 &1684896415
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1684896413}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.1760051, y: 3.345224, z: 1.1047219}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1865921740
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1578,14 +1767,24 @@ PrefabInstance:
       propertyPath: m_Name
       value: MapleTree
       objectReference: {fileID: 0}
+    - target: {fileID: 2943495585636308200, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 7457893061079513468, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
       propertyPath: tapCooldown
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 2279407066166407645, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 441231759}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2943495585636308200, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1651730332}
   m_SourcePrefab: {fileID: 100100000, guid: 756a81bd45144b54a872c231695ca63f, type: 3}
 --- !u!1 &2110014191
 GameObject:
@@ -1711,3 +1910,4 @@ SceneRoots:
   - {fileID: 1399446503}
   - {fileID: 1991865841}
   - {fileID: 1865921740}
+  - {fileID: 1684896415}

--- a/Assets/Scripts/MapleTrees/GameManager.cs
+++ b/Assets/Scripts/MapleTrees/GameManager.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public static GameManager Instance;
+    public int playerMoney = 200; // Starting money
+
+    private void Awake()
+    {
+        if (Instance == null) Instance = this;
+        else Destroy(gameObject);
+    }
+
+    public bool SpendMoney(int amount)
+    {
+        if (playerMoney >= amount)
+        {
+            playerMoney -= amount;
+
+            //UI guys take a look here and update this to match our system for the HUD
+           // UIManager.Instance.UpdateMoneyDisplay(playerMoney); // Update UI
+            return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Scripts/MapleTrees/GameManager.cs.meta
+++ b/Assets/Scripts/MapleTrees/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0cd345a658a2cc7439a64e8d9b496995
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapleTrees/StructureBuilder.cs
+++ b/Assets/Scripts/MapleTrees/StructureBuilder.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using UnityEngine;
+
+public class StructureBuilder : MonoBehaviour
+{
+
+    //ADD THIS CLASS TO ALL UNLOCKABLE STRUCTURES FOR ANIMATING
+
+    public Transform structure;
+    public float buildTime = 1f;
+
+    public void StartBuild()
+    {
+        structure.gameObject.SetActive(true);
+
+        StartCoroutine(BuildSequence());
+    }
+   
+    private IEnumerator BuildSequence()
+    {
+        Vector3 originalScale = structure.localScale;
+        structure.localScale = Vector3.zero;
+
+        float elapsedTime = 0;
+
+        while (elapsedTime < buildTime)
+        {
+            elapsedTime += Time.deltaTime;
+            structure.localScale = Vector3.Lerp(Vector3.zero, originalScale, elapsedTime / buildTime);
+            yield return null;
+        }
+        structure.localScale = originalScale;
+    }
+
+}

--- a/Assets/Scripts/MapleTrees/StructureBuilder.cs.meta
+++ b/Assets/Scripts/MapleTrees/StructureBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fdf332ba2695e004e9c865a7ba33350c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MapleTrees/UnlockZone.cs
+++ b/Assets/Scripts/MapleTrees/UnlockZone.cs
@@ -1,0 +1,32 @@
+
+using UnityEngine;
+
+public class UnlockZone : MonoBehaviour
+{
+
+    [SerializeField] public int price = 100;
+     public StructureBuilder structureToUnlock;
+    private bool isUnlocked = false;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player") && !isUnlocked)
+        {
+            if (GameManager.Instance.SpendMoney(price)) //check if player has balance for unlock
+            {
+                UnlockFeature();
+            }
+            else
+            {
+                Debug.Log("not enough money");
+            }
+        }
+    }
+
+    private void UnlockFeature()
+    {
+        isUnlocked = true;
+        structureToUnlock.StartBuild();
+        gameObject.SetActive(false); //disable trigger zone
+    }
+}

--- a/Assets/Scripts/MapleTrees/UnlockZone.cs.meta
+++ b/Assets/Scripts/MapleTrees/UnlockZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c58a641b60f8e24cbe7ef9f4568decf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Unlock Zones can now be stepped in to check with the game manager if player has enough money. If so, will enable the structure associated with it. Structures will build up over the course of one second (time can be adjusted per structure). Structures will require the StructureBuilder script attached going forward, and should start disabled at game start.

Next push will be adding sequential unlocks for game flow (e.g. after unlocking your first tree, more unlock points will appear for the stand, the boiler, more trees, etc.)

#fm-7