### PR TITLE
#fm-16 #fm-26 added shop inventory scriptable object, added item pric…

### DIFF
--- a/Assets/Scenes/EntropyTestScene.unity
+++ b/Assets/Scenes/EntropyTestScene.unity
@@ -1341,6 +1341,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5047290397725300037, guid: 54bc6a98cab39ce4285d04be74a48131, type: 3}
+      propertyPath: inventory
+      value: 
+      objectReference: {fileID: 11400000, guid: cf610e6285113c24a90f98f8e038e444, type: 2}
+    - target: {fileID: 5047290397725300037, guid: 54bc6a98cab39ce4285d04be74a48131, type: 3}
       propertyPath: dropOffRequirementUIPrefab
       value: 
       objectReference: {fileID: 4332482053209563646, guid: 46d0fd43c3a36734e8e3c45abbc433ff, type: 3}

--- a/Assets/Scripts/Systems/Items/ItemCosts.cs
+++ b/Assets/Scripts/Systems/Items/ItemCosts.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ItemCosts : MonoBehaviour
+{
+    public Dictionary<ItemTypes.Types, float> costDict = new Dictionary<ItemTypes.Types, float>();
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        costDict[ItemTypes.Types.Sap] = 1f;
+        costDict[ItemTypes.Types.SyrupUnfiltered] = 6f;
+        costDict[ItemTypes.Types.SyrupFiltered] = 12f;
+        costDict[ItemTypes.Types.SyrupBottleUnfiltered] = 12f;
+        costDict[ItemTypes.Types.SyrupBottleFiltered] = 24f;
+        costDict[ItemTypes.Types.TaffyTray] = 8f;
+        costDict[ItemTypes.Types.TaffyBox] = 10f;
+        costDict[ItemTypes.Types.IceCreamBucket] = 25f;
+        //costDict[ItemTypes.Types.SnowCandySingle] = 1f;
+        //costDict[ItemTypes.Types.SnowCandyBox] = 1f;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Systems/Items/ItemCosts.cs.meta
+++ b/Assets/Scripts/Systems/Items/ItemCosts.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e533c2c1bc3e5c4c808b06d3725850e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Items/ItemTypes.cs
+++ b/Assets/Scripts/Systems/Items/ItemTypes.cs
@@ -5,9 +5,15 @@ public class ItemTypes
     public enum Types //values here must match existing unity tags
     {
         Sap,
-        Taffee,
-        Syrup,
-        Bacon,
+        SyrupUnfiltered, 
+        SyrupFiltered, 
+        SyrupBottleUnfiltered,
+        SyrupBottleFiltered,
+        TaffyTray,
+        TaffyBox,
+        IceCreamBucket,
+        //SnowCandySingle,
+        //SnowCandyBox
     };
 
     public Types type;

--- a/Assets/Scripts/Systems/Shop/FarmShop.cs
+++ b/Assets/Scripts/Systems/Shop/FarmShop.cs
@@ -5,10 +5,10 @@ public class FarmShop : MonoBehaviour, IDropOffHandler, INPCPickUpHandler
     [Header("Production Variables")]    
     //UI Prefabs
     public GameObject dropOffRequirementUIPrefab;
-    //private ShopInventory inventory = new ShopInventory();
+    [SerializeField] private ShopInventory inventory;
     private DropOffRequirementUI dropOffUI;
     private int maxSyrupRequired = 100;
-    private int currentSyrupCount = 0;
+    private int currentSyrupCount = 0; 
     public string displaySyrupCount = "0";
 
     [SerializeField] private Wallet playerWallet;
@@ -54,8 +54,11 @@ public class FarmShop : MonoBehaviour, IDropOffHandler, INPCPickUpHandler
         {
             playerInventory.DropOffItems(syrupHeld, "Syrup", this.transform);
             currentSyrupCount += syrupHeld;
+            inventory.currentStockDict[ItemTypes.Types.SyrupUnfiltered] += syrupHeld;
             
+
             UnityEngine.Debug.Log($"Syrup dropped off at farm stand! Current count: {currentSyrupCount}");
+            UnityEngine.Debug.Log($"Syrup dropped off at farm stand! Current inventory: {inventory.currentStockDict[ItemTypes.Types.SyrupUnfiltered]}");
 
             // Update Drop-Off UI
             //dropOffUI.UpdateDropOffProgress(currentSapCount, maxSapRequired);

--- a/Assets/Scripts/Systems/Shop/FarmStandInventoryAsset.asset
+++ b/Assets/Scripts/Systems/Shop/FarmStandInventoryAsset.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 22d64af7b26f5b54890763ca4d1a0f68, type: 3}
+  m_Name: FarmStandInventoryAsset
+  m_EditorClassIdentifier: 
+  name: 

--- a/Assets/Scripts/Systems/Shop/FarmStandInventoryAsset.asset.meta
+++ b/Assets/Scripts/Systems/Shop/FarmStandInventoryAsset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cf610e6285113c24a90f98f8e038e444
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Systems/Shop/ShopInventory.cs
+++ b/Assets/Scripts/Systems/Shop/ShopInventory.cs
@@ -2,32 +2,59 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-//[CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/Wallet", order = 1)]
+[CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/ShopInventory", order = 1)]
 public class ShopInventory : AbstractSOContainer
 {
+    public Dictionary<ItemTypes.Types, int> currentStockDict = new Dictionary<ItemTypes.Types, int>();
 
     #region variables
     private GenericItem sap;
-    private GenericItem syrup;
-    private GenericItem taffee;
-    private GenericItem bacon;
-
+    private GenericItem syrupUnfiltered;
+    private GenericItem syrupFiltered;
+    private GenericItem syrupBottleUnfiltered;
+    private GenericItem syrupBottleFiltered;
+    private GenericItem taffyTray;
+    private GenericItem taffyBox;
+    private GenericItem iceCreamBucket;
+    //private GenericItem snowCandySingle;
+    //private GenericItem snowCandyBox;
     #endregion
 
     #region Built-in Functions
     public void Start()
     {
-        InitShop();
+        InitShopItems();
+        InitShopStock();
     }
     #endregion
 
     #region Custom Functions
-    public void InitShop()
+    public void InitShopItems()
     {
         sap.Type = ItemTypes.Types.Sap;
-        syrup.Type = ItemTypes.Types.Syrup;
-        taffee.Type = ItemTypes.Types.Taffee;
-        bacon.Type = ItemTypes.Types.Bacon;
+        syrupUnfiltered.Type = ItemTypes.Types.SyrupUnfiltered;
+        syrupFiltered.Type = ItemTypes.Types.SyrupFiltered;
+        syrupBottleUnfiltered.Type = ItemTypes.Types.SyrupBottleUnfiltered;
+        syrupBottleFiltered.Type = ItemTypes.Types.SyrupBottleFiltered;
+        taffyTray.Type = ItemTypes.Types.TaffyTray;
+        taffyBox.Type = ItemTypes.Types.TaffyBox;
+        iceCreamBucket.Type = ItemTypes.Types.IceCreamBucket;
+        //snowCandySingle.Type = ItemTypes.Types.SnowCandySingle;
+        //snowCandyBox.Type = ItemTypes.Types.SnowCandyBox;
+    }
+
+    public void InitShopStock()
+    {
+        currentStockDict[ItemTypes.Types.Sap] = 0;
+        currentStockDict[ItemTypes.Types.SyrupUnfiltered] = 0;
+        currentStockDict[ItemTypes.Types.SyrupFiltered] = 0;
+        currentStockDict[ItemTypes.Types.SyrupBottleUnfiltered] = 0;
+        currentStockDict[ItemTypes.Types.SyrupBottleFiltered] = 0;
+        currentStockDict[ItemTypes.Types.TaffyTray] = 0;
+        currentStockDict[ItemTypes.Types.TaffyBox] = 0;
+        currentStockDict[ItemTypes.Types.IceCreamBucket] = 0;
+        //currentStockDict[ItemTypes.Types.SnowCandySingle] = 0;
+        //currentStockDict[ItemTypes.Types.SnowCandyBox] = 0;
     }
     #endregion
 }


### PR DESCRIPTION
…e list

scripts\systems\items\ItemCosts.cs contains item costs didn't see tags for SnowCandy, left commented for now

updated ItemTypes.Types to match

scripts/systems/shpo/ShopInventory
- GenericItem's are not currently used but could be used to say what's for sale here (there are better ways)
- currentStockDict contains the data stock per object accessible through the FarmStandInventoryAsset
should be able to create a new instance of this SO for other shops

added asset ref to FarmShop
- was attempting to test update to inventory on unfiltered syrup delivery but trees now disappear in preview mode on the EntropyTestScene, will resolve tomorrow